### PR TITLE
Bump OpenSSH and OpenSSL versions in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.15.3-alpine3.12
 
 # Pinned versions
-ARG OPENSSL_VERSION='1.1.1g-r0'
-ARG OPENSSH_VERSION='8.3_p1-r0'
+ARG OPENSSL_VERSION='1.1.1j-r0'
+ARG OPENSSH_VERSION='8.3_p1-r1'
 
 RUN apk add --no-cache \
   openssl=${OPENSSL_VERSION} \


### PR DESCRIPTION
Fixes previously broken image due to package version problems.